### PR TITLE
Paypal event raised for client

### DIFF
--- a/src/PaddleCheckoutSDK/CheckoutControlController.cs
+++ b/src/PaddleCheckoutSDK/CheckoutControlController.cs
@@ -368,13 +368,8 @@ namespace PaddleCheckoutSDK
                 }
                
             }
-            //new added by sujeet here
             else if (e.Url.ToString().ToLower().Contains("paypal.com"))
-            {
-                Debug.WriteLine("Checkout.PaymentMethodSelected:Paypal");
-
-                //GetFormInfo(e);
-
+            {                 
                 PageSubmittedEventArgs pageArgs = new PageSubmittedEventArgs()
                 {
                     PageName = "Checkout.PaymentMethodSelected:Paypal",

--- a/src/PaddleCheckoutSDK/CheckoutControlController.cs
+++ b/src/PaddleCheckoutSDK/CheckoutControlController.cs
@@ -368,6 +368,23 @@ namespace PaddleCheckoutSDK
                 }
                
             }
+            else if (e.Url.ToString().ToLower().Contains("paypal.com"))
+            {
+                Debug.WriteLine("Checkout.PaymentMethodSelected:Paypal");
+
+                //GetFormInfo(e);
+
+                PageSubmittedEventArgs pageArgs = new PageSubmittedEventArgs()
+                {
+                    PageName = "Checkout.PaymentMethodSelected:Paypal",
+                    UserEmail = checkoutControl.UserSubmittedEmail,
+                    ID = UserID,
+                    UserContry = checkoutControl.UserCountry,
+                    Url = e.Url.ToString()
+                };
+
+                checkoutControl.FirePageSubmittedEvent(pageArgs);
+            }
         }
 
     

--- a/src/PaddleCheckoutSDK/CheckoutControlController.cs
+++ b/src/PaddleCheckoutSDK/CheckoutControlController.cs
@@ -369,17 +369,24 @@ namespace PaddleCheckoutSDK
                
             }
             else if (e.Url.ToString().ToLower().Contains("paypal.com"))
-            {                 
-                PageSubmittedEventArgs pageArgs = new PageSubmittedEventArgs()
+            {
+                if (e.Url != null)
                 {
-                    PageName = "Checkout.PaymentMethodSelected:Paypal",
-                    UserEmail = checkoutControl.UserSubmittedEmail,
-                    ID = UserID,
-                    UserContry = checkoutControl.UserCountry,
-                    Url = e.Url.ToString()
-                };
+                    if (openPaypalUrl(e.Url.ToString()))
+                    {
+                        PageSubmittedEventArgs pageArgs = new PageSubmittedEventArgs()
+                        {
+                            PageName = "Checkout.PaypalLoaded.CloseSDK",
+                            UserEmail = checkoutControl.UserSubmittedEmail,
+                            ID = UserID,
+                            UserContry = checkoutControl.UserCountry,
+                            Url = e.Url.ToString()
+                        };
 
-                checkoutControl.FirePageSubmittedEvent(pageArgs);
+                        checkoutControl.FirePageSubmittedEvent(pageArgs);
+                    }
+                }
+                
             }
         }
 
@@ -536,5 +543,16 @@ namespace PaddleCheckoutSDK
                 InvokeScript();
             }
        }
+
+        private bool openPaypalUrl(string url)
+        {
+            bool _WebLoaded = false;            
+            if (!string.IsNullOrEmpty(url))
+            {
+                System.Diagnostics.Process.Start(url);
+                _WebLoaded = true;
+            }
+            return _WebLoaded;
+        }
     }
 }

--- a/src/PaddleCheckoutSDK/CheckoutControlController.cs
+++ b/src/PaddleCheckoutSDK/CheckoutControlController.cs
@@ -370,23 +370,20 @@ namespace PaddleCheckoutSDK
             }
             else if (e.Url.ToString().ToLower().Contains("paypal.com"))
             {
-                if (e.Url != null)
+                if (openPaypalUrl(e.Url.ToString()))
                 {
-                    if (openPaypalUrl(e.Url.ToString()))
+                    PageSubmittedEventArgs pageArgs = new PageSubmittedEventArgs()
                     {
-                        PageSubmittedEventArgs pageArgs = new PageSubmittedEventArgs()
-                        {
-                            PageName = "Checkout.PaypalLoaded.CloseSDK",
-                            UserEmail = checkoutControl.UserSubmittedEmail,
-                            ID = UserID,
-                            UserContry = checkoutControl.UserCountry,
-                            Url = e.Url.ToString()
-                        };
+                        PageName = "Checkout.PaypalLoaded.CloseSDK",
+                        UserEmail = checkoutControl.UserSubmittedEmail,
+                        ID = UserID,
+                        UserContry = checkoutControl.UserCountry,
+                        Url = e.Url.ToString()
+                    };
 
-                        checkoutControl.FirePageSubmittedEvent(pageArgs);
-                    }
+                    checkoutControl.FirePageSubmittedEvent(pageArgs);
                 }
-                
+
             }
         }
 

--- a/src/PaddleCheckoutSDK/CheckoutControlController.cs
+++ b/src/PaddleCheckoutSDK/CheckoutControlController.cs
@@ -368,6 +368,7 @@ namespace PaddleCheckoutSDK
                 }
                
             }
+            //new added by sujeet here
             else if (e.Url.ToString().ToLower().Contains("paypal.com"))
             {
                 Debug.WriteLine("Checkout.PaymentMethodSelected:Paypal");

--- a/src/PaddleCheckoutSDK/EventDefs.cs
+++ b/src/PaddleCheckoutSDK/EventDefs.cs
@@ -62,6 +62,7 @@ namespace PaddleCheckoutSDK
         /// Transaction id
         /// </summary>
         public string ID { get; set; }
+        public string Url { get; set; }
 
         public override string ToString()
         {
@@ -70,7 +71,7 @@ namespace PaddleCheckoutSDK
             sb.AppendFormat("ID: {0}" , ID + Environment.NewLine); 
             sb.AppendFormat("UserEmail: {0}", UserEmail + Environment.NewLine);
             sb.AppendFormat("UserCountry: {0}", UserContry + Environment.NewLine);
-
+            sb.AppendFormat("URL: {0}", Url + Environment.NewLine);
             return sb.ToString();
         }
     }


### PR DESCRIPTION
### What has been done
- New event raised to notify paypal click on SDK
- 

### How to test
Steps:
- Take the reference of SDK in your client project
- Manage "checkoutControl_PageSubmitted()" event in your client as follows:
a. Check if Page is submitted for event "checkout.paymentmethodselected:paypal" then add your logic there to redirect paypal customer on default browser. Eg:

             if (e.PageName.ToLower().IndexOf("checkout.paymentmethodselected:paypal") >= 0)
                {
                    if (!string.IsNullOrEmpty(e.Url))
                    {
                        //Close checkout window here and
                        //open paypal redirect url in default browser
                       System.Diagnostics.Process.Start(e.Url);
                    }
                }

### Notes
- We needed a workaround to manage PayPal payments via browser.
- We have modified the SDK code to raise PayPal url at client end.
- Now What we require is: 
a. After the payment is complete on PayPal (opened in users default browser) , we need to show the custom Thankyou page on which we display the Product key, Phone no, activation instructions. 
b. Current page after order is complete on PayPal: https://checkout.paddle.com/pay/12741913-chrebe9872d34b1-4ad80d2cf6?display_mode=sdk
c. On our custom Thankyou page we need few parameters which we need to pass from SDK to our custom Thankyou page to generate Product Key. Eg: checkout=**{CHECKOUT_HASH}**&crdr=1&pid=**{OUR_CUSTOM_APP_ID}**&ciso=**{COUNTRY_CODE}**

Thanks